### PR TITLE
Allow addon to work as dependency of another addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,6 @@ module.exports = {
   included: function included(app) {
     this._super.included(app);
 
-    app.import(app.bowerDirectory + '/chartjs/dist/Chart.js');
+    app.import(app.project.bowerDirectory + '/chartjs/dist/Chart.js');
   }
 };


### PR DESCRIPTION
When the ember-cli-chartjs is declared as dependency of another addon, the `app` parameter in  `included` has no  `bowerDirectory` attribute. On the other side, both for main Ember apps and for addons, `app.project` has the correct information.